### PR TITLE
Fixed incorrect link

### DIFF
--- a/public/blog/wordpress-ghost-harp-pt1.md
+++ b/public/blog/wordpress-ghost-harp-pt1.md
@@ -35,7 +35,7 @@ In a totally ideal world, I wanted:
 - Could run on a free hosting platform like Heroku
 - As a bonus, I could hack and improve the system
 
-TL;DR here's the full source of my blog as it is today, on github: [https://github.com/remy/remysharp.com/](github.com/remy/remysharp.com).
+TL;DR here's the full source of my blog as it is today, on github: [https://github.com/remy/remysharp.com/](https://github.com/remy/remysharp.com).
 
 ## Ghost
 


### PR DESCRIPTION
The link was pointing to "https://remysharp.com/2014/09/18/github.com/remy/remysharp.com" instead of "https://github.com/remy/remysharp.com".